### PR TITLE
Socket io adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 		- [Make authorization on connection](#make-authorization-on-connection)
 	- [Joining and leaving rooms](#joining-and-leaving-rooms)
 	- [Broadcast](#broadcast)
+	- [Using multiple instances](#using-multiple-instances)
 	- [Full settings](#full-settings)
 - [Change logs](#change-logs)
 - [License](#license)
@@ -519,12 +520,42 @@ broker.call('io.broadcast', {
 
 Note: You should change the 'io' to the service name you created.
 
+## Using multiple instances
+
+If you plan for a highly available setup (launching multiple instances of this service behind a Load Balancer), 
+you will have to take some extra steps. Due to the nature of WebSockets these instances will need a PubSub capable broker
+to connect to, in order to broadcast messages to sockets which are connected to other instances. For a more
+in depth explanation of this concept, and additional steps that have to be taken (such as Load Balancer configuration), refere to the [Socket.io Documentation](https://socket.io/docs/using-multiple-nodes/).
+
+In order to interconnect this service with other services, start the service with an adapter:
+
+```javascript
+broker.createService({
+    name: 'io',
+    mixins: [SocketIOService],
+    settings:{
+        port:3000, //will call initServer() on broker.start()
+        adapter: {
+            module: require("socket.io-redis"),
+            options: { 
+                host: 'redis', 
+                port: 6379 
+            } 
+        }
+    }
+})
+```
+
 ## Full settings
 
 ```javascript
 settings:{
   port: 3000,
   io: {}, //socket.io options
+  adapter: {
+  	module: require('socket.io-...') // socket.io adapter module
+  	options: {} // socket.io adapter options
+  },
   namespaces: {
     '/':{
       middlewares:[],
@@ -543,6 +574,8 @@ settings:{
 ```
 
 # Change logs
+
+**0.13.2**: Added socket.io adapter options for intercommunication of multiple instances
 
 **0.13.1**: Add request logger.
 

--- a/examples/simple/docker-compose.yml
+++ b/examples/simple/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "2.2"
+
+services:
+  socketio:
+    image: node:11-alpine
+    working_dir: /usr/src/app
+    volumes:
+      - ./../../:/usr/src/app
+    command: npm run example
+    ports:
+      - 3000:3000
+  redis:
+    image: redis
+

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -1,5 +1,6 @@
 const IO = require('socket.io')
 const { ServiceBroker } = require('moleculer')
+const SocketIOAdapter = require('socket.io-redis')
 const SocketIOService = require('../../')
 const express = require('express')
 const fs = require('fs')
@@ -88,6 +89,13 @@ const ioService = broker.createService({
   name: 'io',
   mixins: [SocketIOService],
   settings:{
+  	adapter: {
+  		module: SocketIOAdapter,
+		options: {
+			host: 'redis',
+			port: 6379
+		}
+	},
     namespaces: {
       '/':{
         middlewares:[function(socket, next){

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ module.exports = {
   settings: {
     // port: 3000,
     // io: {}, //socket.io options
+    // adapter: { module: require('socket.io-redis'), options: { host: 'redis', port: 6379 }}
     namespaces: {
       '/': {
         // middlewares:[],
@@ -49,6 +50,9 @@ module.exports = {
       opts = opts || this.settings.io;
       srv = srv || this.server || this.settings.port;
       this.io = new IO(srv, opts);
+      if (this.settings.adapter && this.settings.adapter.module) {
+        this.io.adapter(this.settings.adapter.module(this.settings.adapter.options));
+      }
       this.logger.info('Socket.io API Gateway started.');
     },
     checkIOWhitelist(action, whitelist) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -826,9 +826,9 @@
       "optional": true
     },
     "blob": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "bluebird": {
       "version": "3.5.2",
@@ -1059,6 +1059,12 @@
         "repeating": "^2.0.0"
       }
     },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
+      "dev": true
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1078,22 +1084,22 @@
       "dev": true
     },
     "engine.io": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
-      "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.3.2.tgz",
+      "integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
         "debug": "~3.1.0",
         "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
+        "ws": "~6.1.0"
       }
     },
     "engine.io-client": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
-      "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.1.tgz",
+      "integrity": "sha512-q66JBFuQcy7CSlfAz9L3jH+v7DTT3i6ZEadYcVj2pOs8/0uJHLxKX3WBkGTvULJMdz0tUCyJag0aKT/dpXL9BQ==",
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
@@ -1103,20 +1109,20 @@
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
+        "ws": "~6.1.0",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       }
     },
     "engine.io-parser": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+      "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
+        "blob": "0.0.5",
         "has-binary2": "~1.0.2"
       }
     },
@@ -2377,6 +2383,12 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "notepack.io": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.1.3.tgz",
+      "integrity": "sha512-AgSt+cP5XMooho1Ppn8NB3FFaVWefV+qZoZncYTUSch2GAEwlYLcIIbT5YVkMlFeNHnfwOvc4HDlbvrB5BRxXA==",
+      "dev": true
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -2640,6 +2652,29 @@
         "set-immediate-shim": "^1.0.1"
       }
     },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "dev": true,
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.4.0.tgz",
+      "integrity": "sha512-cu8EF+MtkwI4DLIT0x9P8qNTLFhQD4jLfxLR0cCNkeGzs87FN6879JOJwNQR/1zD7aSYNbU0hgsV9zGY71Itvw==",
+      "dev": true
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
+      "dev": true
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -2738,7 +2773,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "semver": {
       "version": "5.5.0",
@@ -2810,16 +2846,31 @@
       "dev": true
     },
     "socket.io": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
-      "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.2.0.tgz",
+      "integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
+        "debug": "~4.1.0",
+        "engine.io": "~3.3.1",
         "has-binary2": "~1.0.2",
         "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.1.1",
-        "socket.io-parser": "~3.2.0"
+        "socket.io-client": "2.2.0",
+        "socket.io-parser": "~3.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "socket.io-adapter": {
@@ -2828,34 +2879,58 @@
       "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
     },
     "socket.io-client": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
-      "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
+      "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
       "requires": {
         "backo2": "1.0.2",
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
         "debug": "~3.1.0",
-        "engine.io-client": "~3.2.0",
+        "engine.io-client": "~3.3.1",
         "has-binary2": "~1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.2.0",
+        "socket.io-parser": "~3.3.0",
         "to-array": "0.1.4"
       }
     },
     "socket.io-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-      "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
       "requires": {
         "component-emitter": "1.2.1",
         "debug": "~3.1.0",
         "isarray": "2.0.1"
+      }
+    },
+    "socket.io-redis": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-redis/-/socket.io-redis-5.2.0.tgz",
+      "integrity": "sha1-j+KtlEX8UIhvtwq8dZ1nQD1Ymd8=",
+      "dev": true,
+      "requires": {
+        "debug": "~2.6.8",
+        "notepack.io": "~2.1.2",
+        "redis": "~2.8.0",
+        "socket.io-adapter": "~1.1.0",
+        "uid2": "0.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "source-map": {
@@ -2933,10 +3008,11 @@
         "mime-types": "~2.1.18"
       }
     },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",
@@ -2991,13 +3067,11 @@
       "dev": true
     },
     "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+      "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "~1.0.0"
       }
     },
     "xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moleculer-io",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "An API GateWay service for moleculerjs using socket.io",
   "main": "lib/index.js",
   "directories": {
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "babel src -d lib --watch",
-    "example": "node examples/simple/index.js",
+    "example": "npm install && node examples/simple/index.js",
     "build": "babel src -d lib",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -28,13 +28,14 @@
     "chalk": "^2.4.1",
     "debug": "^3.1.0",
     "lodash": "^4.17.10",
-    "socket.io": "^2.1.1"
+    "socket.io": "^2.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "express": "^4.16.3",
     "fs-extra": "^7.0.1",
-    "moleculer": "^0.13.3"
+    "moleculer": "^0.13.3",
+    "socket.io-redis": "^5.2.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ module.exports = {
   settings:{
     // port: 3000,
     // io: {}, //socket.io options
+    // adapter: { module: require('socket.io-redis'), options: { host: 'redis', port: 6379 }}
     namespaces: {
       '/':{
         // middlewares:[],
@@ -39,6 +40,9 @@ module.exports = {
       opts = opts || this.settings.io
       srv = srv || this.server || this.settings.port
       this.io = new IO(srv, opts)
+      if (this.settings.adapter && this.settings.adapter.module) {
+        this.io.adapter(this.settings.adapter.module(this.settings.adapter.options));
+      }
       this.logger.info('Socket.io API Gateway started.')
     },
     checkIOWhitelist(action, whitelist) {


### PR DESCRIPTION
Hey,

with these changes, a socket.io service can now be started and connected to others using a socket.io adapter. This is required for [running the service on multiple nodes](https://socket.io/docs/using-multiple-nodes/) (eg. in a High Availability scenario). I added documentation to the readme and enhanced the example. I did also update socket.io from 2.1.1 to 2.2.0. According to https://github.com/socketio/socket.io/releases/tag/2.2.0 I think the bump is backward compatible and should not break anything.